### PR TITLE
fix: client error && websocket compress error

### DIFF
--- a/pkg/service/websocket.go
+++ b/pkg/service/websocket.go
@@ -42,7 +42,7 @@ func (s *WSService) Conn(ctx context.Context, t transfer.Type, sOpts ...Option) 
 		HandshakeTimeout:  defaultTimeout,
 		ReadBufferSize:    defaultReadBufferSize,
 		WriteBufferSize:   defaultReadBufferSize,
-		EnableCompression: true,
+		EnableCompression: false,
 	}
 
 	if srvOpts.buffers != nil {
@@ -72,7 +72,7 @@ func (s *WSService) Serve(ln net.Listener, sOpts ...Option) error {
 		HandshakeTimeout:  defaultTimeout,
 		ReadBufferSize:    defaultReadBufferSize,
 		WriteBufferSize:   defaultReadBufferSize,
-		EnableCompression: true,
+		EnableCompression: false,
 		CheckOrigin:       func(r *http.Request) bool { return true },
 	}
 


### PR DESCRIPTION
+ 修正 #23 #44 
两位师傅遇到的速度卡顿问题，原因是client没有做携程导致代理请求是顺序处理完一个才会继续处理下一个包。
+ 修正报错：`websocket: discarding reader close error: io: read/write on closed pipe` #26，
该问题是由于`gorilla/websocket` 当开启`EnableCompression`时导致的，临时放弃了`EnableCompression`配置。详情可见：https://github.com/gorilla/websocket/issues/859